### PR TITLE
Fix GitHub pages background

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
             box-sizing: border-box;
         }
 
-        body {
+html, body {
             font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             /* Fallback solid color for older browsers */
             background-color: #1a1a1a !important;
@@ -25,7 +25,7 @@
             color: #ffffff !important;
             position: relative;
             overflow-x: hidden;
-            padding: 15px 10px;
+            padding: 0;
         }
 
         body::before {
@@ -45,7 +45,7 @@
 
         .container {
             text-align: center;
-            padding: 25px 20px;
+            padding: 25px 0;
             max-width: 100%;
             width: 100%;
             max-width: 420px;
@@ -100,7 +100,7 @@
         
         /* Force dark theme for browsers with forced colors */
         @media (forced-colors: active) {
-            body {
+            html, body {
                 background-color: #1a1a1a !important;
                 color: white !important;
             }
@@ -130,7 +130,7 @@
         }
         
         /* Fallback styles for browsers without gradient support */
-        .no-gradients body {
+        .no-gradients html, body {
             background-color: #1a1a1a !important;
             background-image: none !important;
         }
@@ -438,13 +438,13 @@
 
         /* Desktop optimization */
         @media (min-width: 481px) {
-            body {
+            html, body {
                 justify-content: center;
-                padding: 20px;
+                padding: 0;
             }
             
             .container {
-                padding: 35px;
+                padding: 35px 0;
                 max-width: 480px;
                 margin-top: 0;
             }


### PR DESCRIPTION
## Summary
- style both `html` and `body` to keep the dark background when deployed
- remove page padding so the background is truly full screen
- strip horizontal padding from the main container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ba17c45648323a68d4565a0aa5a36